### PR TITLE
Fix mobile menu height

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -151,7 +151,7 @@ const Navbar = () => {
         {/* Menu mobile - aparece abaixo do cabeçalho em telas pequenas */}
         <div
           className={`md:hidden transition-max-height duration-300 ease-in-out overflow-hidden ${
-            mobileMenuOpen ? "max-h-60" : "max-h-0"
+            mobileMenuOpen ? "max-h-80" : "max-h-0"
           }`}
         >
           <div className="flex flex-col pt-2 pb-3 space-y-1 border-t border-purple-800 mt-4">


### PR DESCRIPTION
## Summary
- prevent the 'Contato' item from being clipped when the mobile menu is open

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c3ea080b88326908b4a0bbf229269