### PR TITLE
Fix carousel captions for mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,13 +8,13 @@ import DecorationsSection from "../components/DecorationsSection";
 import ContactSection from "../components/ContactSection";
 import Footer from "../components/Footer";
 
-import { slideImages, structureItems, kidsAreaData, services } from "@/data/mockData";
+import { slides, structureItems, kidsAreaData, services } from "@/data/mockData";
 
 export default function Home() {
   return (
     <div className="flex flex-col items-center min-h-screen overflow-x-hidden">
       <Navbar />
-      <HeroSection images={slideImages} />
+      <HeroSection slides={slides} />
       <StructureSection items={structureItems} kidsArea={kidsAreaData} />
       <ServicesSection services={services} />
       <DecorationsSection />

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,9 +2,10 @@
 
 import MainCarousel from "./MainCarousel";
 import { Henny_Penny } from "next/font/google";
+import type { Slide } from "@/data/mockData";
 
 interface HeroSectionProps {
-  images: string[];
+  slides: Slide[];
 }
 
 const hennyPenny = Henny_Penny({
@@ -12,7 +13,7 @@ const hennyPenny = Henny_Penny({
   subsets: ["latin"],
 });
 
-export default function HeroSection({ images }: HeroSectionProps) {
+export default function HeroSection({ slides }: HeroSectionProps) {
   return (
     <section id="inicio" className="w-full bg-gradient-to-br from-indigo-950 to-purple-900 relative pb-16 pt-24">
       <div className="absolute bottom-0 left-0 w-full h-20 overflow-hidden">
@@ -37,7 +38,7 @@ export default function HeroSection({ images }: HeroSectionProps) {
         </div>
 
         <div className="w-full sm:w-[90%] max-w-[1920px] px-0 sm:px-0">
-          <MainCarousel images={images} />
+          <MainCarousel slides={slides} />
         </div>
       </div>
     </section>

--- a/src/components/MainCarousel.tsx
+++ b/src/components/MainCarousel.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useState, useEffect } from "react";
 import { Henny_Penny } from "next/font/google";
+import type { Slide } from "@/data/mockData";
 
 const hennyPenny = Henny_Penny({
   weight: "400",
@@ -10,10 +11,9 @@ const hennyPenny = Henny_Penny({
 });
 
 interface MainCarouselProps {
-  images: string[];
+  slides: Slide[];
 }
-
-export default function MainCarousel({ images }: MainCarouselProps) {
+export default function MainCarousel({ slides }: MainCarouselProps) {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [isAutoPlaying, setIsAutoPlaying] = useState(true);
 
@@ -29,11 +29,11 @@ export default function MainCarousel({ images }: MainCarouselProps) {
   }, [currentSlide, isAutoPlaying]);
 
   const nextSlide = () => {
-    setCurrentSlide((prev) => (prev === images.length - 1 ? 0 : prev + 1));
+    setCurrentSlide((prev) => (prev === slides.length - 1 ? 0 : prev + 1));
   };
 
   const prevSlide = () => {
-    setCurrentSlide((prev) => (prev === 0 ? images.length - 1 : prev - 1));
+    setCurrentSlide((prev) => (prev === 0 ? slides.length - 1 : prev - 1));
   };
 
   const goToSlide = (index: number) => {
@@ -46,7 +46,7 @@ export default function MainCarousel({ images }: MainCarouselProps) {
     <div className="relative w-[100%] aspect-[16/9] max-w-[1920px] my-12">
       {/* Carrossel com cantos arredondados */}
       <div className="relative w-full h-full rounded-3xl overflow-hidden shadow-2xl bg-gradient-to-r from-indigo-500/10 to-purple-500/10">
-        {images.map((src, index) => (
+        {slides.map((slide, index) => (
           <div
             key={index}
             className={`absolute w-full h-full transition-all duration-700 ${
@@ -57,7 +57,7 @@ export default function MainCarousel({ images }: MainCarouselProps) {
           >
             <div className="relative w-full h-full">
               <Image
-                src={src}
+                src={slide.src}
                 alt={`Slide ${index + 1}`}
                 fill
                 style={{ objectFit: "cover" }}
@@ -66,14 +66,11 @@ export default function MainCarousel({ images }: MainCarouselProps) {
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
               <div className="absolute bottom-0 left-0 p-8 md:p-12 text-white w-full hidden md:block">
-                <h2 className="text-3xl md:text-5xl font-bold mb-3 transform transition-all duration-700 translate-y-0">
-                  Bem-vindo à{" "}
-                  <span className={hennyPenny.className}>
-                    Mansão dos Sonhos
-                  </span>
+                <h2 className={`text-3xl md:text-5xl font-bold mb-3 transform transition-all duration-700 translate-y-0 ${hennyPenny.className}`}>
+                  {slide.title}
                 </h2>
                 <p className="text-lg md:text-xl max-w-xl transform transition-all duration-700 translate-y-0">
-                  O espaço perfeito para sua comemoração sem preocupações
+                  {slide.description}
                 </p>
               </div>
             </div>
@@ -169,7 +166,7 @@ export default function MainCarousel({ images }: MainCarouselProps) {
 
       {/* Indicadores de slide */}
       <div className="absolute bottom-6 left-1/2 transform -translate-x-1/2 flex space-x-2">
-        {images.map((_, index) => (
+        {slides.map((_, index) => (
           <button
             key={index}
             onClick={() => goToSlide(index)}
@@ -181,6 +178,12 @@ export default function MainCarousel({ images }: MainCarouselProps) {
             aria-label={`Ir para slide ${index + 1}`}
           />
         ))}
+      </div>
+
+      {/* Texto abaixo do carrossel para dispositivos móveis */}
+      <div className="md:hidden text-center text-white mt-6 px-6">
+        <h2 className={`text-2xl font-bold mb-2 ${hennyPenny.className}`}>{slides[currentSlide].title}</h2>
+        <p className="text-base">{slides[currentSlide].description}</p>
       </div>
     </div>
   );

--- a/src/data/mockData.tsx
+++ b/src/data/mockData.tsx
@@ -24,10 +24,28 @@ export interface Service {
   buttonLink?: string;
 }
 
-export const slideImages: string[] = [
-  "/images/mesas.png",
-  "/images/mesas2.png",
-  "/images/brinquedos.png",
+export interface Slide {
+  src: string;
+  title: string;
+  description: string;
+}
+
+export const slides: Slide[] = [
+  {
+    src: "/images/mesas.png",
+    title: "Bem-vindo à Mansão dos Sonhos",
+    description: "O espaço perfeito para sua comemoração sem preocupações",
+  },
+  {
+    src: "/images/mesas2.png",
+    title: "Ambientes aconchegantes",
+    description: "Espaços planejados para todas as idades",
+  },
+  {
+    src: "/images/brinquedos.png",
+    title: "Diversão garantida",
+    description: "Brinquedos e atrações para alegrar a festa",
+  },
 ];
 
 export const structureItems: StructureItem[] = [


### PR DESCRIPTION
## Summary
- convert slide data to include captions
- show dynamic caption for current slide below mobile carousel

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c663635d0832681798e831dbf95f2