### PR TITLE
Fix modal close button z-index

### DIFF
--- a/src/components/DecorationGallery.tsx
+++ b/src/components/DecorationGallery.tsx
@@ -341,7 +341,7 @@ const DecorationGallery = ({
           >
             {/* Botão de fechar */}
             <button
-              className="absolute top-4 right-4 bg-black/60 text-white rounded-full p-2"
+              className="absolute top-4 right-4 bg-black/60 text-white rounded-full p-2 z-10"
               onClick={closeModal}
               aria-label="Fechar visualização"
             >


### PR DESCRIPTION
## Summary
- fix z-index for close button in gallery modal

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ca1bdcd2483269fc6e70bafcb6585